### PR TITLE
Some "packaging" fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,8 @@ setup(name='sonoff-python',
         "Operating System :: OS Independent",
       ],
       packages=['sonoff'],
+      install_requires=[
+        'requests>=2.12.4',
+        'websocket-client>=0.54.0'
+       ],
       zip_safe=False)

--- a/sonoff/__init__.py
+++ b/sonoff/__init__.py
@@ -1,3 +1,8 @@
 name = "sonoff-python"
 
-from sonoff import Sonoff
+import sys
+
+if sys.version_info.major >= 3:
+    from sonoff.sonoff import Sonoff
+else:
+    from sonoff import Sonoff


### PR DESCRIPTION
* import working in Python 3.6+ (with 2.x compability),
* [install_requires](https://packaging.python.org/discussions/install-requires-vs-requirements/) for automatic dependency download during pip install