### PR TITLE
Fix README example to switch on

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ devices = s.get_devices()
 if devices:
     # We found a device, lets turn something on
     device_id = devices[0]['deviceid']
-    s.switch('on', device_id, 0)
+    s.switch('on', device_id, None)
 
 # update config
 config.api_region = s.get_api_region


### PR DESCRIPTION
Using s.switch('on', device_id, 0) didn't work out of the box, it trows
the following error:

Traceback (most recent call last):
  File "/tmp/test.py", line 14, in <module>
    s.switch('on', device_id, 0)
  File "/usr/local/lib/python2.7/dist-packages/sonoff/sonoff.py", line 246, in switch
    params = { 'switches' : device['params']['switches'] }
KeyError: 'switches'

Updating the command to s.switch('on', device_id, None) works like a
charm