### PR TITLE
 Bugfix in 'do_reconnect' method 

### DIFF
--- a/sonoff/sonoff.py
+++ b/sonoff/sonoff.py
@@ -45,7 +45,7 @@ class Sonoff():
 
             self.update_devices() # to get the devices list
         except:
-            do_login()
+            self.do_login()
 
     def do_login(self):
         import uuid


### PR DESCRIPTION
In 'do_reconnect' method there is a bug. If 'self.set_wshost()' or 'self.update_devices()' raise exception, the except statement should call 'self.do_login()' instead 'do_login()'.